### PR TITLE
Add pin modes used in newer versions of Firmata

### DIFF
--- a/src/main/java/org/firmata4j/Pin.java
+++ b/src/main/java/org/firmata4j/Pin.java
@@ -67,7 +67,28 @@ public interface Pin {
         /**
          * Pin included in I2C setup
          */
-        I2C
+        I2C,
+        /**
+         * Pin configured for 1-wire
+         */
+        ONEWIRE,
+        /**
+         * Pin configured for stepper motor
+         */
+        STEPPER,
+        /**
+         * Pin configured for rotary encoders
+         */
+        ENCODER,
+        /**
+         * Pin configured for serial communication
+         */
+        SERIAL,
+        /**
+         * Enable internal pull-up resistor for pin
+         */
+        PULLUP,
+        // TODO: #define PIN_MODE_IGNORE         0x7F // pin configured to be ignored by digitalWrite and capabilityResponse
     }
 
     /**


### PR DESCRIPTION
The latest version 2.5.0 of Firmata uses more Pin-Nodes. this PR addes the necessary Pin-Modes to at least allow to communicate with this version as otherwise ArrayOutOfBoundsException are reported during startup when unknown pin-modes are encountered.