### PR TITLE
Add support for the internall pullup resistors which current Firmata supports

### DIFF
--- a/src/main/java/org/firmata4j/firmata/FirmataDevice.java
+++ b/src/main/java/org/firmata4j/firmata/FirmataDevice.java
@@ -460,7 +460,8 @@ public class FirmataDevice implements IODevice, SerialPortEventListener {
         int pinId = (Integer) event.getBodyItem(PIN_ID);
         if (pinId < pins.size()) {
             FirmataPin pin = pins.get(pinId);
-            if (Pin.Mode.INPUT.equals(pin.getMode())) {
+            if (Pin.Mode.INPUT.equals(pin.getMode()) ||
+            		Pin.Mode.PULLUP.equals(pin.getMode())) {
                 pin.updateValue((Integer) event.getBodyItem(PIN_VALUE));
             }
         }

--- a/src/main/java/org/firmata4j/ui/JPin.java
+++ b/src/main/java/org/firmata4j/ui/JPin.java
@@ -76,6 +76,10 @@ public class JPin extends JLabel implements PinEventListener {
         iconset.put("on", new ImageIcon(classLoader.getResource("img/green-on.png")));
         iconset.put("off", new ImageIcon(classLoader.getResource("img/green-off.png")));
 
+        ICONS.put(Pin.Mode.PULLUP, iconset);
+        iconset.put("on", new ImageIcon(classLoader.getResource("img/green-on.png")));
+        iconset.put("off", new ImageIcon(classLoader.getResource("img/green-off.png")));
+
         iconset = new HashMap<>();
         ICONS.put(Pin.Mode.OUTPUT, iconset);
         iconset.put("on", new ImageIcon(classLoader.getResource("img/blue-on.png")));


### PR DESCRIPTION
Some digital sensors require a pullup to get a stable on/off signal, current Firmata supports this via a separate Mode PULLUP which is supported since PR #3. 

Required changes a minimal, basically Pin.Mode.PULLUP needs to be handled equally to Pin.Mode.INPUT, it can be used by using `device.getPin(2).setMode(Mode.PULLUP)` instead of `device.getPin(2).setMode(Mode.INPUT)`