### PR TITLE
Ensure that the started thread is stopped if initialization fails

### DIFF
--- a/src/main/java/org/firmata4j/firmata/FirmataDevice.java
+++ b/src/main/java/org/firmata4j/firmata/FirmataDevice.java
@@ -120,6 +120,7 @@ public class FirmataDevice implements IODevice, SerialPortEventListener {
                             SerialPort.STOPBITS_1,
                             SerialPort.PARITY_NONE);
                 } catch (SerialPortException ex) {
+                	parserExecutor.interrupt();
                     throw new IOException("Cannot start firmata device", ex);
                 }
             }
@@ -128,6 +129,7 @@ public class FirmataDevice implements IODevice, SerialPortEventListener {
                 port.addEventListener(this);
                 sendMessage(FirmataMessageFactory.REQUEST_FIRMWARE);
             } catch (SerialPortException | IOException ex) {
+               	parserExecutor.interrupt();
                 throw new IOException("Cannot start firmata device", ex);
             }
         }


### PR DESCRIPTION
Otherwise we leave threads lingering and preventing the Java app from closing when initialization fails (e.g. wrong/occupied port)