### PR TITLE
separate hardware definition from Firmata Device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target/
+.idea/
+*.iml

--- a/src/main/java/org/firmata4j/firmata/FirmataParser.java
+++ b/src/main/java/org/firmata4j/firmata/FirmataParser.java
@@ -1,0 +1,63 @@
+package org.firmata4j.firmata;
+
+import org.firmata4j.firmata.parser.WaitingForMessageState;
+import org.firmata4j.fsm.FiniteStateMachine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ArrayBlockingQueue;
+
+/**
+ * @author akia
+ * @since 2018-01
+ */
+public abstract class FirmataParser extends FiniteStateMachine {
+
+    private static final long NO_DATA_DELAY = 15;
+    private static final long WAIT_FOR_TERMINATION_DELAY = 3000;
+    private final Logger logger = LoggerFactory.getLogger(FirmataParser.class);
+    private final ArrayBlockingQueue<byte[]> byteQueue = new ArrayBlockingQueue<>(128);
+    private Thread parserExecutor;
+    private boolean running;
+
+    public FirmataParser() {
+        super(WaitingForMessageState.class);
+        parserExecutor = new Thread(new JobRunner(), "firmata-parser-thread");
+        running = true;
+        parserExecutor.start();
+    }
+
+    public void stopParser() {
+        running = false;
+        byteQueue.clear();
+        try {
+            parserExecutor.join(WAIT_FOR_TERMINATION_DELAY);
+        } catch (InterruptedException e) {
+            logger.error("parser was not stopped successfully");
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public void parse(byte[] bytes) {
+        if (!byteQueue.offer(bytes)) {
+            logger.warn("parser byte queue limit reached. some bytes where skipped");
+        }
+    }
+
+    private class JobRunner implements Runnable {
+        public void run() {
+            try {
+                while (running) {
+                    if (byteQueue.isEmpty()) {
+                        Thread.sleep(NO_DATA_DELAY);
+                    } else {
+                        process(byteQueue.take());
+                    }
+                }
+            } catch (InterruptedException e) {
+                logger.error("firmata parser executor was stopped abnormally");
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/src/main/java/org/firmata4j/firmata/transport/AbstractFirmataTransport.java
+++ b/src/main/java/org/firmata4j/firmata/transport/AbstractFirmataTransport.java
@@ -1,0 +1,46 @@
+package org.firmata4j.firmata.transport;
+
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * thew hardware than Firmata is implemented on
+ */
+public abstract class AbstractFirmataTransport implements FirmataTransportInterface {
+
+    /**
+     * queue of the received messages.
+     * any device will just queue received data here and leave the rest to FirmataDevice
+     */
+    private BlockingQueue<byte[]> byteQueue;
+
+    /**
+     * Device connector need to know where to put received data on.
+     * if must be present before starting the device.
+     *
+     * @param byteQueue byte queue from frimataDevice
+     */
+    public final void setByteQueue(BlockingQueue<byte[]> byteQueue) {
+        this.byteQueue = byteQueue;
+    }
+
+    protected void queueDeviceResponse(byte[] bytes) {
+        if (bytes == null || bytes.length == 0) {
+            return;
+        }
+        while (!byteQueue.offer(bytes)) {
+            // trying to place bytes to queue until it succeeds
+            //this implementation can cause issue with concurrent messages.
+        }
+    }
+
+    @Override
+    public final void startTransport() throws IOException {
+        if (byteQueue == null) {
+            throw new IllegalStateException("byteQueue was not set before starting device");
+        }
+        initializeConnector();
+    }
+
+    protected abstract void initializeConnector() throws IOException;
+}

--- a/src/main/java/org/firmata4j/firmata/transport/AbstractFirmataTransport.java
+++ b/src/main/java/org/firmata4j/firmata/transport/AbstractFirmataTransport.java
@@ -1,46 +1,32 @@
 package org.firmata4j.firmata.transport;
 
+import org.firmata4j.firmata.FirmataParser;
+
 import java.io.IOException;
-import java.util.concurrent.BlockingQueue;
 
 /**
  * thew hardware than Firmata is implemented on
  */
 public abstract class AbstractFirmataTransport implements FirmataTransportInterface {
 
-    /**
-     * queue of the received messages.
-     * any device will just queue received data here and leave the rest to FirmataDevice
-     */
-    private BlockingQueue<byte[]> byteQueue;
+    private FirmataParser parser;
 
-    /**
-     * Device connector need to know where to put received data on.
-     * if must be present before starting the device.
-     *
-     * @param byteQueue byte queue from frimataDevice
-     */
-    public final void setByteQueue(BlockingQueue<byte[]> byteQueue) {
-        this.byteQueue = byteQueue;
-    }
-
-    protected void queueDeviceResponse(byte[] bytes) {
-        if (bytes == null || bytes.length == 0) {
-            return;
-        }
-        while (!byteQueue.offer(bytes)) {
-            // trying to place bytes to queue until it succeeds
-            //this implementation can cause issue with concurrent messages.
-        }
+    protected final void queueDeviceResponse(byte[] bytes) {
+        parser.parse(bytes);
     }
 
     @Override
     public final void startTransport() throws IOException {
-        if (byteQueue == null) {
-            throw new IllegalStateException("byteQueue was not set before starting device");
+        if (parser == null) {
+            throw new IOException("parser was not set before starting transport");
         }
         initializeConnector();
     }
 
     protected abstract void initializeConnector() throws IOException;
+
+    @Override
+    public void setParser(FirmataParser parser) {
+        this.parser = parser;
+    }
 }

--- a/src/main/java/org/firmata4j/firmata/transport/FirmataTransportInterface.java
+++ b/src/main/java/org/firmata4j/firmata/transport/FirmataTransportInterface.java
@@ -1,0 +1,28 @@
+package org.firmata4j.firmata.transport;
+
+import java.io.IOException;
+
+/**
+ * @author akia
+ * @since 2018-01
+ */
+public interface FirmataTransportInterface {
+
+    /**
+     * start transport and initialize connector
+     */
+    void startTransport() throws IOException;
+
+    /**
+     * shutdown connector and stop the transport
+     */
+    void stopTransport() throws IOException;
+
+    /**
+     * send a message to device
+     *
+     * @param bytes data to send
+     */
+    void sendMessage(byte[] bytes) throws IOException;
+
+}

--- a/src/main/java/org/firmata4j/firmata/transport/FirmataTransportInterface.java
+++ b/src/main/java/org/firmata4j/firmata/transport/FirmataTransportInterface.java
@@ -1,5 +1,7 @@
 package org.firmata4j.firmata.transport;
 
+import org.firmata4j.firmata.FirmataParser;
+
 import java.io.IOException;
 
 /**
@@ -25,4 +27,10 @@ public interface FirmataTransportInterface {
      */
     void sendMessage(byte[] bytes) throws IOException;
 
+    /**
+     * it will set the parser for parsing response from transport
+     *
+     * @param parser response parser
+     */
+    void setParser(FirmataParser parser);
 }

--- a/src/main/java/org/firmata4j/firmata/transport/SerialFirmataTransport.java
+++ b/src/main/java/org/firmata4j/firmata/transport/SerialFirmataTransport.java
@@ -44,8 +44,10 @@ public class SerialFirmataTransport extends AbstractFirmataTransport implements 
     @Override
     public void stopTransport() throws IOException {
         try {
-            port.purgePort(SerialPort.PURGE_RXCLEAR | SerialPort.PURGE_TXCLEAR);
-            port.closePort();
+            if (port.isOpened()) {
+                port.purgePort(SerialPort.PURGE_RXCLEAR | SerialPort.PURGE_TXCLEAR);
+                port.closePort();
+            }
         } catch (SerialPortException ex) {
             throw new IOException("Cannot properly stop firmata device", ex);
         }

--- a/src/main/java/org/firmata4j/firmata/transport/SerialFirmataTransport.java
+++ b/src/main/java/org/firmata4j/firmata/transport/SerialFirmataTransport.java
@@ -1,0 +1,74 @@
+package org.firmata4j.firmata.transport;
+
+import jssc.SerialPort;
+import jssc.SerialPortEvent;
+import jssc.SerialPortEventListener;
+import jssc.SerialPortException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * @author ali
+ * since 1/7/2018.
+ */
+public class SerialFirmataTransport extends AbstractFirmataTransport implements SerialPortEventListener {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SerialFirmataTransport.class);
+    private final SerialPort port;
+
+    public SerialFirmataTransport(String portName) {
+        this.port = new SerialPort(portName);
+    }
+
+
+    @Override
+    public void initializeConnector() throws IOException {
+        if (!port.isOpened()) {
+            try {
+                port.openPort();
+                port.setParams(
+                        SerialPort.BAUDRATE_57600,
+                        SerialPort.DATABITS_8,
+                        SerialPort.STOPBITS_1,
+                        SerialPort.PARITY_NONE);
+                port.setEventsMask(SerialPort.MASK_RXCHAR);
+                port.addEventListener(this);
+            } catch (SerialPortException ex) {
+                throw new IOException("Cannot start firmata device", ex);
+            }
+        }
+
+    }
+
+    @Override
+    public void stopTransport() throws IOException {
+        try {
+            port.purgePort(SerialPort.PURGE_RXCLEAR | SerialPort.PURGE_TXCLEAR);
+            port.closePort();
+        } catch (SerialPortException ex) {
+            throw new IOException("Cannot properly stop firmata device", ex);
+        }
+    }
+
+    @Override
+    public void sendMessage(byte[] bytes) throws IOException {
+        try {
+            port.writeBytes(bytes);
+        } catch (SerialPortException ex) {
+            throw new IOException("Cannot send message to device", ex);
+        }
+    }
+
+    @Override
+    public void serialEvent(SerialPortEvent event) {
+        // queueing data from input buffer to processing by FSM logic
+        if (event.isRXCHAR() && event.getEventValue() > 0) {
+            try {
+                queueDeviceResponse(port.readBytes());
+            } catch (SerialPortException ex) {
+                LOGGER.error("Cannot read from device", ex);
+            }
+        }
+    }
+}

--- a/src/main/java/org/firmata4j/fsm/FiniteStateMachine.java
+++ b/src/main/java/org/firmata4j/fsm/FiniteStateMachine.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Finite State Machine base implementation.<br/>
  * It leaves implementation of event handling in
- * {@link #onEvent(com.codefactory.event.Event)} method to the user.<br/>
+ * {@link #onEvent(org.firmata4j.fsm.Event)} method to the user.<br/>
  * The finite state machine is not thread-safe by its nature. This
  * implementation does not cope with simultaneously received bytes. The bytes
  * have to be fed to the FSM one by one in a single thread that should define
@@ -97,7 +97,7 @@ public abstract class FiniteStateMachine {
      * {@link IllegalArgumentException} is thrown otherwise.
      *
      * @param stateClass the state class
-     * @throw IllegalArgumentException when the state class does not provide a
+     * @throws IllegalArgumentException when the state class does not provide a
      * constructor taking {@link FiniteStateMachine} instance as a single
      * parameter.
      */
@@ -167,5 +167,5 @@ public abstract class FiniteStateMachine {
      *
      * @param event the event
      */
-    public abstract void onEvent(Event event);
+    protected abstract void onEvent(Event event);
 }


### PR DESCRIPTION
I am using this library for connecting my android phone to arduino with OTG cable. to do so, I had to change the code to define another type of device instead of fixed serial hardcoded into FirmataDevice implementation. I cleaned up my changes and polished it a bit for anybody who needs it. It is backward compatible and the old constructor is still there.
now this library can be used as a core library for communicating with firmata through any platform ( Bluetooth, websocket, RF, ...)
let me know if you think additional changes are required.

1. now a custom device can be connected to FirmataDevice
2. adding git ignore for intellij idea files