### PR TITLE
bug on FirmataDevice start fail.

### DIFF
--- a/src/main/java/org/firmata4j/firmata/FirmataDevice.java
+++ b/src/main/java/org/firmata4j/firmata/FirmataDevice.java
@@ -121,7 +121,8 @@ public class FirmataDevice implements IODevice {
                 transport.start();
                 sendMessage(FirmataMessageFactory.REQUEST_FIRMWARE);
             } catch (IOException ex) {
-                transport.start();
+                parser.stop();
+                transport.stop();
                 throw ex;
             }
         }


### PR DESCRIPTION
if transport fails to start, it tries to start again instead of trying to stop (my bad). 😞 
also we need to stop the started parser before throwing exception (guess who's) 😆 