### PR TITLE
Properly stop firmata parser thread in FirmataParser.stop()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target/
 .idea/
 *.iml
+.classpath
+.project

--- a/src/main/java/org/firmata4j/firmata/parser/FirmataParser.java
+++ b/src/main/java/org/firmata4j/firmata/parser/FirmataParser.java
@@ -61,6 +61,11 @@ public abstract class FirmataParser extends FiniteStateMachine implements Parser
     public void stop() {
         if (running.getAndSet(false)) {
             byteQueue.clear();
+
+            // interrupt the thread to ensure it falls out of the loop
+            // and sees the shutdown request
+            parserExecutor.interrupt();
+
             try {
                 parserExecutor.join(WAIT_FOR_TERMINATION_DELAY);
             } catch (InterruptedException e) {


### PR DESCRIPTION
When shutting down, sometimes the firmata-parser-thread is kept running because it never returns from the call to byteQueue.take(). In my case this causes an application to not stop because a non-daemon thread is still running.

A parserThread.interrupt() in stop() causes the take() to return with an InterruptedException and thus stops the thread correctly.

I also tried to add a unit-test for this, but the whole project is not set up for it, are you interested in a separate PR with a few unit-tests?