### PR TITLE
Fix NullPointerException and rename incorrectly spelled method

### DIFF
--- a/src/main/java/org/firmata4j/firmata/FirmataDevice.java
+++ b/src/main/java/org/firmata4j/firmata/FirmataDevice.java
@@ -108,7 +108,7 @@ public class FirmataDevice implements IODevice {
         transport.setParser(parser);
         this.transport = transport;
     }
-    
+
     /**
      * Constructs FirmataDevice instance using the specified transport and
      * protocol.
@@ -359,7 +359,7 @@ public class FirmataDevice implements IODevice {
             byte pinId = (Byte) event.getBodyItem(PIN_ID);
             FirmataPin pin = new FirmataPin(FirmataDevice.this, pinId);
             for (byte i : (byte[]) event.getBodyItem(PIN_SUPPORTED_MODES)) {
-                pin.addSupprotedMode(Pin.Mode.resolve(i));
+                pin.addSupportedMode(Pin.Mode.resolve(i));
             }
             pins.add(pin.getIndex(), pin);
             if (pin.getSupportedModes().isEmpty()) {
@@ -370,12 +370,12 @@ public class FirmataDevice implements IODevice {
                 try {
                     sendMessage(FirmataMessageFactory.pinStateRequest(pinId));
                     if (pinId > 0 && pinId % 14 == 0) { // 14 pins on Arduino UNO get initialized without delay
-                        /* If the pin count is too high (i.e. Arduino Mega), then 
-                        * too many firmata requests in a row can overflow the 
-                        * device's serial input buffer. 
+                        /* If the pin count is too high (i.e. Arduino Mega), then
+                        * too many firmata requests in a row can overflow the
+                        * device's serial input buffer.
                         * One solution is to yield a little time between
-                        * requests to allow the device to respond. The response 
-                        * may then safely sit in the host's much larger serial 
+                        * requests to allow the device to respond. The response
+                        * may then safely sit in the host's much larger serial
                         * input buffer until it is dealt with by onPinStateReceive
                         */
                         Thread.sleep(10);

--- a/src/main/java/org/firmata4j/firmata/FirmataPin.java
+++ b/src/main/java/org/firmata4j/firmata/FirmataPin.java
@@ -185,7 +185,7 @@ public class FirmataPin implements Pin {
      *
      * @param mode the mode
      */
-    void addSupprotedMode(Mode mode) {
+    void addSupportedMode(Mode mode) {
         supportedModes.add(mode);
     }
 

--- a/src/main/java/org/firmata4j/firmata/parser/FirmataParser.java
+++ b/src/main/java/org/firmata4j/firmata/parser/FirmataParser.java
@@ -77,7 +77,7 @@ public class FirmataParser implements Parser {
 
     @Override
     public void parse(byte[] bytes) {
-        if (!byteQueue.offer(bytes)) {
+        if (bytes != null && !byteQueue.offer(bytes)) {
             LOGGER.warn("Parser reached byte queue limit. Some bytes were skipped.");
         }
     }

--- a/src/test/java/org/firmata4j/firmata/parser/FirmataParserTest.java
+++ b/src/test/java/org/firmata4j/firmata/parser/FirmataParserTest.java
@@ -45,18 +45,49 @@ public class FirmataParserTest {
         };
         FirmataParser parser = new FirmataParser(fsm);
         parser.start();
-        parser.parse(new byte[] {1, 2, 3});
-        int i = 0;
-        while(eventCount.get() < 3 && i < 20) {
-            Thread.sleep(100);
-            i++;
+        try {
+            parser.parse(new byte[]{1, 2, 3});
+            int i = 0;
+            while (eventCount.get() < 3 && i < 20) {
+                Thread.sleep(100);
+                i++;
+            }
+            assertEquals(
+                    "Should receive 3 events for each byte",
+                    3,
+                    eventCount.get()
+            );
+        } finally {
+            parser.stop();
         }
-        assertEquals(
-                "Should receive 3 events for each byte",
-                3,
-                eventCount.get()
-        );
-        parser.stop();
+    }
+
+    @Test
+    public void testParseNull() throws InterruptedException {
+        final AtomicInteger eventCount = new AtomicInteger(0);
+        FiniteStateMachine fsm = new FiniteStateMachine() {
+            @Override
+            public void handle(Event event) {
+                eventCount.incrementAndGet();
+            }
+        };
+        FirmataParser parser = new FirmataParser(fsm);
+        parser.start();
+        try {
+            parser.parse(null);
+            int i = 0;
+            while (eventCount.get() == 0 && i < 10) {
+                Thread.sleep(100);
+                i++;
+            }
+            assertEquals(
+                    "Should receive no events at all with null bytes array",
+                    0,
+                    eventCount.get()
+            );
+        } finally {
+            parser.stop();
+        }
     }
 
     private static void assertIfThreadStillRunning(final String contains) throws InterruptedException {


### PR DESCRIPTION
I saw an NPE when SerialPort.readBytes() returns null, better to not to try to parse the response in this case