### PR TITLE
doc(init): add documentation and errror message for required queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,21 @@ upload it as follows:
 - Select the port in `Tools -> Port` (it is already selected if you have uploaded something to your Arduino)
 - Click on `Upload` button
 
+Note that **firmata4j** is focused to be client for the `StandardFirmata` firmware.
+Although there are several other firmwares that support Firmata protocol, those
+may implement only a featured subset of the protocol. A firmware has to respond
+to the following requests in order for **firmata4j** to initialize properly:
+
+- `REPORT_FIRMWARE`
+- `CAPABILITY_QUERY`
+- `PIN_STATE_QUERY`
+- `ANALOG_MAPPING_QUERY`
+
 ## Cases
 
 - [Easy Peripherals for the Internet of Things](https://repositorio-aberto.up.pt/bitstream/10216/84433/2/138208.pdf)
 - [Modelovanie a Riadenie Hybridných Systémov s Využitím Petriho Sietí Vyšších Úrovní](http://www.fei.stuba.sk/docs/2016/autoreferaty/autoref_Kucera.pdf)
+- [Programmazione di Sistemi Embedded con Linguaggi ad Agenti: un Caso di Studio basato su Jason e Arduino](https://amslaurea.unibo.it/9188/1/cozzolino_francesco_tesi.pdf)
 - [Using **firmata4j** in Closure](https://github.com/cowlike/firmata4j-samples-clojure)
 
 ## Contributing

--- a/README_ru.md
+++ b/README_ru.md
@@ -212,10 +212,22 @@ Arduino IDE содержит реализацию протокола Firmata. Ч
 - Выбрать порт в `Tools -> Port` (уже выбрано, если вы ранее загружали что-либо на Arduino)
 - Нажать кнопку `Upload`
 
+Обратите внимание, что **firmata4j** фокусируется на том, чтобы работать с
+прошивкой `StandardFirmata`. Несмотря на то, что существуют другие прошивки с
+поддержкой Firmata, некоторые из них поддерживают только избранные функции
+протокола. Чтобы **firmata4j** смогла пройти инициализацию, прошивка должна
+отвечать на следующие запросы: 
+
+- `REPORT_FIRMWARE`
+- `CAPABILITY_QUERY`
+- `PIN_STATE_QUERY`
+- `ANALOG_MAPPING_QUERY`
+
 ## Примеры использования
 
 - [Easy Peripherals for the Internet of Things](https://repositorio-aberto.up.pt/bitstream/10216/84433/2/138208.pdf)
 - [Modelovanie a Riadenie Hybridných Systémov s Využitím Petriho Sietí Vyšších Úrovní](http://www.fei.stuba.sk/docs/2016/autoreferaty/autoref_Kucera.pdf)
+- [Programmazione di Sistemi Embedded con Linguaggi ad Agenti: un Caso di Studio basato su Jason e Arduino](https://amslaurea.unibo.it/9188/1/cozzolino_francesco_tesi.pdf)
 - [Использование **firmata4j** в Closure](https://github.com/cowlike/firmata4j-samples-clojure)
 
 ## Развитие библиотеки

--- a/src/main/java/org/firmata4j/firmata/FirmataDevice.java
+++ b/src/main/java/org/firmata4j/firmata/FirmataDevice.java
@@ -185,7 +185,10 @@ public class FirmataDevice implements IODevice {
         long timeout = 100;
         while (!isReady()) {
             if (timePassed >= TIMEOUT) {
-                throw new InterruptedException("Connection timeout");
+                throw new InterruptedException("Connection timeout.\n"
+                        + "Please, make sure the board runs a firmware that supports Firmata protocol.\n"
+                        + "The firmware has to implement callbacks for CAPABILITY_QUERY, PIN_STATE_QUERY and ANALOG_MAPPING_QUERY in order for the initialization to work."
+                );
             }
             timePassed += timeout;
             Thread.sleep(timeout);


### PR DESCRIPTION
Not all of the firmata supporting firmwares implement the whole protocol.
firmata4j presumes that some of the requests are supported. This commit
documents the requests that are required during initialization.

Related to #35