### PR TITLE
Change Jssc Version to updated version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,12 +33,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.resource.directory>src/main/resources</project.resource.directory>
         <test.resource.directory>src/test/resources</test.resource.directory>
-        <jssc.version>2.8.0</jssc.version>
+        <jssc.version>2.9.4</jssc.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>org.scream3r</groupId>
+            <groupId>io.github.java-native</groupId>
             <artifactId>jssc</artifactId>
             <version>${jssc.version}</version>
         </dependency>


### PR DESCRIPTION
https://stackoverflow.com/questions/64740659/georgenotfound-s-minecraftshocker-plugin-if-you-have-this-error-jssc-2-8-x86, here it states they changed the JSSC version to 2.9.2 to fix the EXCEPTION_ACCESS_VIOLATION. This should be changed to fix that error.