### PR TITLE
fix 55: Do not update pin value from pin state response message as th…

### DIFF
--- a/src/main/java/org/firmata4j/firmata/FirmataDevice.java
+++ b/src/main/java/org/firmata4j/firmata/FirmataDevice.java
@@ -433,9 +433,6 @@ public class FirmataDevice implements IODevice {
             FirmataPin pin = pins.get(pinId);
             if (pin.getMode() == null) {
                 pin.initMode(Pin.Mode.resolve((Byte) event.getBodyItem(PIN_MODE)));
-                pin.initValue((Long) event.getBodyItem(PIN_VALUE));
-            } else {
-                pin.updateValue((Long) event.getBodyItem(PIN_VALUE));
             }
             if (!pinStateRequestQueue.isEmpty()) {
                 byte pid = pinStateRequestQueue.poll();


### PR DESCRIPTION
fix #55 : Do not update pin value from pin state response message as the state in the message is not the actual value of the pin. See https://github.com/firmata/protocol/blob/master/protocol.md